### PR TITLE
"username" is deprecated change2 tweet.user

### DIFF
--- a/2022/snscrape/tweets.py
+++ b/2022/snscrape/tweets.py
@@ -13,7 +13,7 @@ for tweet in sntwitter.TwitterSearchScraper(query).get_items():
     if len(tweets) == limit:
         break
     else:
-        tweets.append([tweet.date, tweet.username, tweet.content])
+        tweets.append([tweet.date, tweet.user, tweet.content])
         
 df = pd.DataFrame(tweets, columns=['Date', 'User', 'Tweet'])
 print(df)


### PR DESCRIPTION
Changed tweet.username to tweet.user as "username" is deprecated.

jesse@sliver:/opt/git/twitter_api/2022/Twitter_API$ python3 tweets.py  tweets.py:17: FutureWarning: username is deprecated, use user.username instead
  tweets.append([tweet.date, tweet.username, tweet.content])